### PR TITLE
Fix warnings for linter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,7 @@
   "plugins": ["react", "prettier"],
   "rules": {
     "prettier/prettier": "error",
-    "no-unused-vars": "warn",
+    "no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
     "no-console": "off",
     "func-names": "off",
     "no-process-exit": "off",

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -2,12 +2,12 @@ const express = require('express');
 
 const router = express.Router();
 
-const User = require('../models/User');
+//const User = require('../models/User');
 
-router.get('/', (req, res) => {});
+router.get('/', (_req, _res) => {});
 
-router.post('/register', (req, res) => {});
+router.post('/register', (_req, _res) => {});
 
-router.post('/login', (req, res) => {});
+router.post('/login', (_req, _res) => {});
 
 module.exports = router;

--- a/backend/server.test.js
+++ b/backend/server.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-commented-out-tests */
 const request = require('supertest');
 
 const app = require('./app');


### PR DESCRIPTION
Add option to the linter to ignore function parameters that start with _
Add _ to functions parameters where warnings are generated